### PR TITLE
remove break from the switch

### DIFF
--- a/src/token.cpp
+++ b/src/token.cpp
@@ -395,10 +395,8 @@ namespace vlark
             break;
         case token_type::Left_Bracket:
             return token_type::Right_Bracket;
-            break;
         case token_type::Left_Paren:
             return token_type::Right_Paren;
-            break;
         default:
             return token_type::Invalid;
         }


### PR DESCRIPTION
- no need for a break when we use a return in the switch case. it was overseen.
- fixed